### PR TITLE
Fix for latest CoreOS release, remove -i from docker runtime.

### DIFF
--- a/mongo-replica-config.service
+++ b/mongo-replica-config.service
@@ -28,7 +28,7 @@ ExecStart=/bin/bash -c "\
     echo trying to init the replicaset...; \
     \
     function mongo() { \
-      docker run -it --rm mongo:2.6 \
+      docker run -t --rm mongo:2.6 \
         mongo $COREOS_PRIVATE_IPV4/admin \
         -u siteRootAdmin -p $SITE_ROOT_PWD \
         --eval \"$1\"; \

--- a/mongo@.service
+++ b/mongo@.service
@@ -60,7 +60,7 @@ ExecStartPost=/bin/bash -c "\
           \
           echo Creating the siteUserAdmin user... ; \
           docker run \
-            -it --rm \
+            -t --rm \
             mongo:2.6 \
             mongo $COREOS_PRIVATE_IPV4/admin \
             --eval \"db.createUser({user:'siteUserAdmin', \
@@ -69,7 +69,7 @@ ExecStartPost=/bin/bash -c "\
           \
           echo Creating the siteRootAdmin user... ; \
           docker run \
-            -it --rm \
+            -t --rm \
             mongo:2.6 \
             mongo $COREOS_PRIVATE_IPV4/admin \
             --eval \"db.createUser({user:'siteRootAdmin', \


### PR DESCRIPTION
Newest version of docker in CoreOS 557.0.0 (1.4.1) does not allow interactive terminals without a true tty, and will fail with 'cannot enable tty mode on non tty input'